### PR TITLE
Implement move_base goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,23 @@ If you would like to use a custom microphone, such as the Respeaker which is ava
 </launch>
 ```
 
+# Using the `move_base` node
+
+The `ros_msft_luis_move_base` node is provided to translate the intents into `move_base` navigation goals. It currently understands the following intents:
+
+- "Move Forward" / "Move Backward", followed by a distance expressed in meters, feet or yards. For example: "move forward 2 meters", "move backward 3 feet".
+- "Turn Left" / "Turn Right", followed by an angle expressed in degrees. For example: "turn left 34 degrees". If no angle is given, a default of 90 degrees will be used, so you can just say "turn right" for example.
+- "Stop", which cancels all current navigation.
+
+To launch the node, you can use the provided launch configuration:
+
+```
+roslaunch ros_msft_luis luis_move_base.launch
+```
+
 ### Using containers with ROS
 
-The Azure Cognitive Services support edge deployments using [containers](https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-container-support), including Speech-to-Text and Lanugage Understanding Service (LUIS). These models can be deployed directly to the robot if there are sufficient resources, or can be deployed to an edge server or Kubernetes cluster.
+The Azure Cognitive Services support edge deployments using [containers](https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-container-support), including Speech-to-Text and Language Understanding Service (LUIS). These models can be deployed directly to the robot if there are sufficient resources, or can be deployed to an edge server or Kubernetes cluster.
 
 **Starting the Speech-to-Text container**
 

--- a/ros_msft_luis/launch/luis_move_base.launch
+++ b/ros_msft_luis/launch/luis_move_base.launch
@@ -1,0 +1,13 @@
+<launch>
+  <node name="luis_test" pkg="ros_msft_luis" type="ros_msft_luis_node" output="screen">
+    <param name="luiskey" value="Enter your Primary Key mentioned in the luis portal" />
+    <param name="region" value="Enter your location mentioned in the luis portal" />
+    <param name="appid" value="Enter your APP ID mentioned in the luis portal" />
+    <param name="kwkey" value="Enter your key mentioned in the speech studio" />
+    <param name="kwregion" value="Enter your location mentioned in the speech studio" />
+    <param name="keywordpath" value="Enter the location of the of .table file that you downloaded from the speech studio" />
+    <param name="keyword" value="Enter your custom keyword" />
+  </node>
+  <node name="luis_test_move_base" pkg="ros_msft_luis_move_base" type="ros_msft_luis_move_base_node" output="screen">
+  </node>
+</launch>

--- a/ros_msft_luis/src/azure_cs_luis.cpp
+++ b/ros_msft_luis/src/azure_cs_luis.cpp
@@ -120,7 +120,12 @@ void parseAndPublishFromJson(std::string luisJson)
                             JSON_Object *resolution_object = json_object_dotget_object(entity_object, "resolution");
                             if (resolution_object)
                             {
-                                float value = atof(json_object_dotget_string(resolution_object, "value"));
+                                float value = 0.0;
+                                const char* value_string = json_object_dotget_string(resolution_object, "value");
+
+                                if (value_string)
+                                    value = atof(value_string);
+
                                 std::string unit = json_object_dotget_string(resolution_object, "unit");
 
                                 intent.dimension.value = value;

--- a/ros_msft_luis/src/azure_cs_luis.cpp
+++ b/ros_msft_luis/src/azure_cs_luis.cpp
@@ -131,6 +131,18 @@ void parseAndPublishFromJson(std::string luisJson)
                                 intent.dimension.value = value;
                                 intent.dimension.unit = unit;
                             }
+                        } else if (type == "builtin.number") {
+                            JSON_Object *resolution_object = json_object_dotget_object(entity_object, "resolution");
+                            if (resolution_object)
+                            {
+                                std::string value_string = json_object_dotget_string(resolution_object, "value");
+                                std::string subtype = json_object_dotget_string(resolution_object, "subtype");
+
+                                ros_msft_luis_msgs::Entity new_entity;
+                                new_entity.name = subtype;
+                                new_entity.value = value_string;
+                                intent.entities.push_back(new_entity);
+                            }
                         }
                     }
                 }

--- a/ros_msft_luis/src/azure_cs_luis.cpp
+++ b/ros_msft_luis/src/azure_cs_luis.cpp
@@ -117,6 +117,7 @@ void parseAndPublishFromJson(std::string luisJson)
                         std::string type = json_object_dotget_string(entity_object, "type");
                         if (type == "builtin.dimension")
                         {
+                            // Convert builtin.dimension LUIS entity to message dimension
                             JSON_Object *resolution_object = json_object_dotget_object(entity_object, "resolution");
                             if (resolution_object)
                             {
@@ -131,7 +132,10 @@ void parseAndPublishFromJson(std::string luisJson)
                                 intent.dimension.value = value;
                                 intent.dimension.unit = unit;
                             }
-                        } else if (type == "builtin.number") {
+                        }
+                        else if (type == "builtin.number")
+                        {
+                            // Copy all builtin.number LUIS entities to message entities
                             JSON_Object *resolution_object = json_object_dotget_object(entity_object, "resolution");
                             if (resolution_object)
                             {

--- a/ros_msft_luis_move_base/src/ros_msft_luis_move_base.cpp
+++ b/ros_msft_luis_move_base/src/ros_msft_luis_move_base.cpp
@@ -16,7 +16,8 @@ const std::string LEFT = "turn left";
 
 std::unique_ptr<actionlib::SimpleActionClient<move_base_msgs::MoveBaseAction>> ac;
 
-std::string str_tolower(std::string s) {
+std::string str_tolower(std::string s)
+{
     std::transform(s.begin(), s.end(), s.begin(), 
                    [](unsigned char c){ return std::tolower(c); }
                   );
@@ -46,10 +47,13 @@ void intentCallback(const ros_msft_luis_msgs::TopIntent::ConstPtr& msg)
     {
         float angle;
 
-        if (msg->entities.empty()) {
+        if (msg->entities.empty())
+        {
             // By default, turn 90 degrees
             angle = 90.0;
-        } else {
+        }
+        else
+        {
             auto entity = msg->entities.at(0);
             angle = stof(entity.value);
         }


### PR DESCRIPTION
This PR is in support of #16. /cc @ooeygui @amelhassan 

Forward/backward movement (in meters and feet) and right/left rotation (in degrees) are implemented.

I had to make two changes to the LUIS node itself:

- Modify `parseAndPublishFromJson()` to add the entities to the intent message (for rotation, the degrees are not recognised as a dimension, but they appear as a number entity).
- The keyword recogniser only worked once in my tests; after a successful keyword recognition it would just stop working. I now create a new recogniser at each iteration of the `ros::ok()` loop.

I also added the following:

- [x] Support for feet (just convert feet to meters).
- [x] Implement the STOP intent to cancel the current actions, in case the robot gets lost.
