### PR TITLE
Add the new stop keyword params. Fixes to param parsing

### DIFF
--- a/ros_msft_luis/launch/luis.launch
+++ b/ros_msft_luis/launch/luis.launch
@@ -7,5 +7,7 @@
     <param name="kwregion" value="Enter your location mentioned in the speech studio" />
     <param name="keywordpath" value="Enter the location of the of .table file that you downloaded from the speech studio" />
     <param name="keyword" value="Enter your custom keyword" />
+    <param name="stopkeywordpath" value="Enter the location of the of stop .table file that you downloaded from the speech studio" />
+    <param name="stopkeyword" value="Enter your custom stop keyword" />
   </node>
 </launch>

--- a/ros_msft_luis/launch/luis_move_base.launch
+++ b/ros_msft_luis/launch/luis_move_base.launch
@@ -7,6 +7,8 @@
     <param name="kwregion" value="Enter your location mentioned in the speech studio" />
     <param name="keywordpath" value="Enter the location of the of .table file that you downloaded from the speech studio" />
     <param name="keyword" value="Enter your custom keyword" />
+    <param name="stopkeywordpath" value="Enter the location of the of stop .table file that you downloaded from the speech studio" />
+    <param name="stopkeyword" value="Enter your custom stop keyword" />
   </node>
   <node name="luis_test_move_base" pkg="ros_msft_luis_move_base" type="ros_msft_luis_move_base_node" output="screen">
   </node>

--- a/ros_msft_luis/launch/luis_moveit.launch
+++ b/ros_msft_luis/launch/luis_moveit.launch
@@ -7,6 +7,8 @@
     <param name="kwregion" value="Enter your location mentioned in the speech studio" />
     <param name="keywordpath" value="Enter the location of the of .table file that you downloaded from the speech studio" />
     <param name="keyword" value="Enter your custom keyword" />
+    <param name="stopkeywordpath" value="Enter the location of the of stop .table file that you downloaded from the speech studio" />
+    <param name="stopkeyword" value="Enter your custom stop keyword" />
   </node>
   <node name="luis_test_moveit" pkg="ros_msft_luis_moveit" type="ros_msft_luis_moveit_node" output="screen">
   </node>

--- a/ros_msft_luis/src/azure_cs_luis.cpp
+++ b/ros_msft_luis/src/azure_cs_luis.cpp
@@ -508,7 +508,7 @@ int main(int argc, char **argv)
     }
 
     if (g_stopKeyWord.empty() &&
-        !nhPrivate.getParam("stopKeyword", g_stopKeyWord))
+        !nhPrivate.getParam("stopkeyword", g_stopKeyWord))
     {
         ROS_ERROR("luis Stop KeyWord value has not been set");
         nh.shutdown();
@@ -524,7 +524,7 @@ int main(int argc, char **argv)
     }
 
     if (g_stopKeyWordPath.empty() &&
-        !nhPrivate.getParam("keywordpath", g_stopKeyWordPath))
+        !nhPrivate.getParam("stopkeywordpath", g_stopKeyWordPath))
     {
         ROS_ERROR("luis Stop KeyWordPath has not been set");
         nh.shutdown();


### PR DESCRIPTION
Added `stopkeywordpath` and `stopkeyword` to the launch files.

Fixed uppercase K in `stopKeyword`.

Changed`g_stopKeyWordPath` to read from the `stopkeywordpath` param.